### PR TITLE
Added url_params config option

### DIFF
--- a/config.php
+++ b/config.php
@@ -17,4 +17,11 @@ class Config {
     public $format = 'json';              // 'json', 'jsonp' or 'xml'
     public $callback = 'processShares';   // default jsonp callback function name
 
+    /* added URL parameters for services */
+    public $url_params = array(
+        'facebook'  => array(
+            'app_access_token'  => ''
+        )
+    );
+
 }

--- a/share_count.php
+++ b/share_count.php
@@ -108,18 +108,21 @@ class shareCount {
         );
 
         if ($services) {
-          if (!is_array($services)) {
-            $services = explode(',', $services);
-          }
-
-          foreach($services as $service) {
-              $provider = $shareLinks[$service];
-              @$this->getCount($service, $provider[0] . $this->url, $provider[1]);
-          }
+            if (!is_array($services)) { $services = explode(',', $services); }
         } else {
-          foreach($shareLinks as $service=>$provider) {
-              @$this->getCount($service, $provider[0] . $this->url, $provider[1]);
-          }
+            $services = array_keys($shareLinks);
+        }
+
+        foreach($services as $service) {
+            $provider = $shareLinks[$service];
+            $url_params = '';
+
+            if (array_key_exists($service, $this->config->url_params)) {
+                $url_params = '&' . http_build_query($this->config->url_params[$service]);
+            }
+
+            $url = $provider[0] . $this->url . $url_params;
+            @$this->getCount($service, $url, $provider[1]);
         }
 
         switch($this->format) {


### PR DESCRIPTION
We ran into an issue we're our server was getting throttled by the Facebook Graphs API due to too many requests to the public API.

I've implemented a way to add extra URL parameters to the service URL's so that you can add an access token or whatever else you need to the URL.

You set these by editing the `$url_params` array inside of `config.php` like so:
```javascript
    public $url_params = array(
        'facebook'  => array(
            'app_access_token'  => 'YOUR_ACCESS_TOKEN_HERE'
        ),
        'linkedin'  => array(
            'some_url_param'  => 'url_param_value_here'
        )
    );
```